### PR TITLE
Add right mouse button support for Linux

### DIFF
--- a/src/com/soulsspeedruns/organizer/savelist/SaveList.java
+++ b/src/com/soulsspeedruns/organizer/savelist/SaveList.java
@@ -728,6 +728,12 @@ public class SaveList extends JList<SaveListEntry> implements ListSelectionListe
 		e.consume();
 		requestFocusInWindow();
 		handleSelection(e);
+
+    // On Linux, isPopupTrigger is only set on mouse pressed events and not on mouse
+    // released events.
+    if (System.getProperty("os.name").equalsIgnoreCase("linux") && e.isPopupTrigger()) {
+			new SaveListContextMenu(this, e.getX(), e.getY());
+    }
 	}
 
 

--- a/src/com/soulsspeedruns/organizer/savelist/SaveList.java
+++ b/src/com/soulsspeedruns/organizer/savelist/SaveList.java
@@ -728,12 +728,8 @@ public class SaveList extends JList<SaveListEntry> implements ListSelectionListe
 		e.consume();
 		requestFocusInWindow();
 		handleSelection(e);
-
-    // On Linux, isPopupTrigger is only set on mouse pressed events and not on mouse
-    // released events.
-    if (System.getProperty("os.name").equalsIgnoreCase("linux") && e.isPopupTrigger()) {
+		if (e.isPopupTrigger())
 			new SaveListContextMenu(this, e.getX(), e.getY());
-    }
 	}
 
 


### PR DESCRIPTION
This PR adds the `isPopupTrigger` check to the `mousePressed` event as well, allowing Linux to be supported.

According to [this](https://stackoverflow.com/questions/5736872/java-popup-trigger-in-linux) and [this](https://stackoverflow.com/questions/38468270/how-to-implement-a-popup-menu-in-swing-that-works-both-under-windows-and-linux), and perfectly in line with the Java motto "build once, run everywhere", Windows will report that `isPopupTrigger` is true on right click in the `mouseReleased` event but not in `mousePressed`, and Linux will do the polar opposite. 

The official Oracle [tutorial](https://docs.oracle.com/javase/tutorial/uiswing/components/menu.html#popup) processes the flag in both handlers, so this should be fine.