### PR TITLE
Always keep savelist selection visible

### DIFF
--- a/src/com/soulsspeedruns/organizer/savelist/SaveList.java
+++ b/src/com/soulsspeedruns/organizer/savelist/SaveList.java
@@ -772,14 +772,18 @@ public class SaveList extends JList<SaveListEntry> implements ListSelectionListe
 	@Override
 	public void navigatedToPrevious()
 	{
-		setSelectedIndex(Math.max(0, getSelectedIndex() - 1));
+		int prevIndex = Math.max(0, getSelectedIndex() - 1);
+		setSelectedIndex(prevIndex);
+		ensureIndexIsVisible(prevIndex);
 	}
 
 
 	@Override
 	public void navigatedToNext()
 	{
-		setSelectedIndex(Math.min(getModel().getSize(), getSelectedIndex() + 1));
+		int nextIndex = Math.min(getModel().getSize(), getSelectedIndex() + 1);
+		setSelectedIndex(nextIndex);
+		ensureIndexIsVisible(nextIndex);
 	}
 
 }


### PR DESCRIPTION
Added functionality to always keep the selected element visible within the savelist viewport when utilizing the prev/next navigation listeners. The viewport now scrolls when these listeners are used for selections above or below what is currently visible.